### PR TITLE
Add lightweight desktop agent for screenshots and idle tracking

### DIFF
--- a/.openai/setup.sh
+++ b/.openai/setup.sh
@@ -5,3 +5,11 @@ if [ -f package-lock.json ]; then
 else
   npm install
 fi
+
+if [ -d desktop-agent ]; then
+  if [ -f desktop-agent/package-lock.json ]; then
+    (cd desktop-agent && npm ci)
+  else
+    (cd desktop-agent && npm install)
+  fi
+fi

--- a/desktop-agent/README.md
+++ b/desktop-agent/README.md
@@ -1,0 +1,16 @@
+# Desktop Agent
+
+This folder contains a lightweight Electron application that captures screenshots and tracks idle time in the background.
+
+## Setup
+
+From the `desktop-agent` directory install dependencies and start the agent:
+
+```bash
+npm install
+npm run start
+```
+
+## Configuration
+
+Edit `config.json` to set your `user_id`, optional `project_id` and Supabase credentials before running the agent.

--- a/desktop-agent/config.json
+++ b/desktop-agent/config.json
@@ -1,0 +1,6 @@
+{
+  "user_id": "uuid_here",
+  "project_id": "optional_project_id",
+  "supabase_url": "https://fkpiqcxkmrtaetvfgcli.supabase.co",
+  "supabase_key": "your-anon-key"
+}

--- a/desktop-agent/package.json
+++ b/desktop-agent/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "desktop-agent",
+  "version": "1.0.0",
+  "main": "src/main.js",
+  "scripts": {
+    "start": "electron ."
+  },
+  "dependencies": {
+    "electron": "^28.3.3",
+    "screenshot-desktop": "^1.14.0",
+    "node-desktop-idle": "^1.0.3",
+    "@supabase/supabase-js": "^2.49.8"
+  }
+}

--- a/desktop-agent/renderer/index.html
+++ b/desktop-agent/renderer/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Time Flow Desktop Agent</title>
+  </head>
+  <body>
+    <h1>Time Flow Desktop Agent Running</h1>
+  </body>
+</html>

--- a/desktop-agent/renderer/renderer.js
+++ b/desktop-agent/renderer/renderer.js
@@ -1,0 +1,1 @@
+console.log('Desktop agent renderer running');

--- a/desktop-agent/src/main.js
+++ b/desktop-agent/src/main.js
@@ -1,0 +1,112 @@
+const { app, BrowserWindow } = require('electron');
+const path = require('path');
+const fs = require('fs');
+const screenshot = require('screenshot-desktop');
+const idle = require('node-desktop-idle');
+const { createClient } = require('@supabase/supabase-js');
+
+const configPath = path.join(__dirname, '..', 'config.json');
+const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+
+const supabase = createClient(config.supabase_url, config.supabase_key);
+
+let idleStart = null;
+
+function createWindow() {
+  const win = new BrowserWindow({
+    width: 300,
+    height: 200,
+    webPreferences: {
+      preload: path.join(__dirname, '../renderer/renderer.js'),
+    },
+  });
+
+  win.setMenuBarVisibility(false);
+  win.loadFile(path.join(__dirname, '../renderer/index.html'));
+}
+
+async function uploadScreenshot() {
+  try {
+    const img = await screenshot({ format: 'png' });
+    const fileName = `${Date.now()}.png`;
+    const { error: uploadError } = await supabase.storage
+      .from('screenshots')
+      .upload(`${config.user_id}/${fileName}`, img, { contentType: 'image/png' });
+    if (uploadError) throw uploadError;
+
+    const { data: publicUrl } = supabase.storage
+      .from('screenshots')
+      .getPublicUrl(`${config.user_id}/${fileName}`);
+    const imageUrl = publicUrl.publicUrl;
+
+    await fetch(`${config.supabase_url}/functions/v1/screenshot`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        apikey: config.supabase_key,
+        Authorization: `Bearer ${config.supabase_key}`,
+      },
+      body: JSON.stringify({
+        user_id: config.user_id,
+        project_id: config.project_id,
+        timestamp: new Date().toISOString(),
+        image_url: imageUrl,
+      }),
+    });
+  } catch (err) {
+    console.error('Failed to capture screenshot', err);
+  }
+}
+
+function startScreenshotLoop() {
+  setInterval(() => {
+    void uploadScreenshot();
+  }, 300000); // 5 minutes
+}
+
+async function sendIdleLog(idleEnd) {
+  const durationMinutes = Math.round((idleEnd - idleStart) / 60000);
+  try {
+    await fetch(`${config.supabase_url}/functions/v1/idle-log`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        apikey: config.supabase_key,
+        Authorization: `Bearer ${config.supabase_key}`,
+      },
+      body: JSON.stringify({
+        user_id: config.user_id,
+        project_id: config.project_id,
+        idle_start: new Date(idleStart).toISOString(),
+        idle_end: new Date(idleEnd).toISOString(),
+        duration_minutes: durationMinutes,
+      }),
+    });
+  } catch (err) {
+    console.error('Failed to send idle log', err);
+  }
+}
+
+function startIdleMonitor() {
+  setInterval(() => {
+    const idleMs = idle.getIdleTime();
+    if (idleStart === null && idleMs >= 180000) {
+      idleStart = Date.now() - idleMs;
+    }
+    if (idleStart !== null && idleMs < 1000) {
+      const end = Date.now();
+      void sendIdleLog(end);
+      idleStart = null;
+    }
+  }, 10000);
+}
+
+app.whenReady().then(() => {
+  createWindow();
+  startScreenshotLoop();
+  startIdleMonitor();
+});
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') app.quit();
+});


### PR DESCRIPTION
## Summary
- create `desktop-agent` Electron application
- capture screenshots every 5 minutes and upload to Supabase
- detect user idle time and log to Supabase
- provide `config.json` and run instructions
- install agent dependencies during setup

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*