### PR TITLE
Fix electron script to gracefully handle missing build output

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "build/electron/main.cjs",
   "scripts": {
     "start": "concurrently \"npm:dev\" \"npm:electron\"",
-    "electron": "tsc -p tsconfig.electron.json && mv build/electron/main.js build/electron/main.cjs && electron build/electron/main.cjs",
+    "electron": "tsc -p tsconfig.electron.json && [ -f build/electron/main.js ] && mv build/electron/main.js build/electron/main.cjs && electron build/electron/main.cjs || echo 'main.js not found'",
     "dev:electron": "ts-node-esm --project tsconfig.electron.json electron/main.ts",
     "dev": "vite",
     "build": "electron-builder",


### PR DESCRIPTION
## Summary
- improve `electron` NPM script to check for `main.js`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build:electron` *(fails: missing type definition files for electron & node)*